### PR TITLE
Create return request button plugin

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,369 @@
+/* Return Button Plugin Admin Styles */
+
+/* Admin Page Header */
+.wrap h1 {
+    margin-bottom: 20px;
+}
+
+/* Return Request Details */
+.return-request-details {
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+    margin: 20px 0;
+}
+
+.return-request-details .form-table {
+    margin: 0;
+}
+
+.return-request-details .form-table th {
+    width: 200px;
+    font-weight: 600;
+    color: #23282d;
+    background-color: #f9f9f9;
+    border-bottom: 1px solid #e1e1e1;
+    padding: 15px;
+}
+
+.return-request-details .form-table td {
+    padding: 15px;
+    border-bottom: 1px solid #e1e1e1;
+    vertical-align: top;
+}
+
+.return-request-details .form-table tr:last-child th,
+.return-request-details .form-table tr:last-child td {
+    border-bottom: none;
+}
+
+/* Status Badges */
+.status-pending {
+    background-color: #f39c12;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.status-processing {
+    background-color: #3498db;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.status-completed {
+    background-color: #27ae60;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.status-cancelled_by_admin,
+.status-cancelled_by_user {
+    background-color: #e74c3c;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+/* Uploaded Files */
+.uploaded-files {
+    margin: 15px 0;
+}
+
+.file-item {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    margin-bottom: 10px;
+}
+
+.file-item a {
+    color: #007cba;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.file-item a:hover {
+    text-decoration: underline;
+}
+
+.file-size {
+    margin-left: 10px;
+    color: #6c757d;
+    font-size: 12px;
+}
+
+/* List Table Customizations */
+.wp-list-table .column-id {
+    width: 80px;
+}
+
+.wp-list-table .column-order_id {
+    width: 120px;
+}
+
+.wp-list-table .column-status {
+    width: 120px;
+}
+
+.wp-list-table .column-request_date {
+    width: 150px;
+}
+
+.wp-list-table .column-actions {
+    width: 100px;
+}
+
+/* Form Styling */
+.return-request-details form {
+    margin-top: 30px;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+}
+
+.return-request-details form h3 {
+    margin-top: 0;
+    margin-bottom: 20px;
+    color: #23282d;
+    border-bottom: 2px solid #007cba;
+    padding-bottom: 10px;
+}
+
+.return-request-details select,
+.return-request-details textarea {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 8px;
+    font-size: 14px;
+}
+
+.return-request-details select {
+    min-width: 200px;
+}
+
+.return-request-details textarea {
+    width: 100%;
+    max-width: 500px;
+    min-height: 100px;
+    resize: vertical;
+}
+
+/* Button Styling */
+.button-primary {
+    background-color: #007cba !important;
+    border-color: #007cba !important;
+}
+
+.button-primary:hover {
+    background-color: #005a87 !important;
+    border-color: #005a87 !important;
+}
+
+/* Settings Page */
+.form-table th {
+    width: 250px;
+}
+
+.form-table input[type="number"] {
+    width: 80px;
+}
+
+.form-table .description {
+    font-style: italic;
+    color: #666;
+    margin-top: 5px;
+}
+
+/* Dashboard Widget Style */
+.return-requests-widget {
+    background: #fff;
+    border: 1px solid #e5e5e5;
+    border-radius: 4px;
+    padding: 20px;
+    margin: 20px 0;
+}
+
+.return-requests-widget h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    font-size: 18px;
+    color: #23282d;
+}
+
+.return-requests-stats {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.stat-item {
+    flex: 1;
+    text-align: center;
+    padding: 15px;
+    background-color: #f8f9fa;
+    border-radius: 4px;
+    border: 1px solid #dee2e6;
+}
+
+.stat-number {
+    font-size: 24px;
+    font-weight: bold;
+    color: #007cba;
+    display: block;
+}
+
+.stat-label {
+    font-size: 12px;
+    color: #6c757d;
+    text-transform: uppercase;
+    margin-top: 5px;
+}
+
+/* Search Box Styling */
+.search-box {
+    margin-bottom: 20px;
+}
+
+.search-box input[type="search"] {
+    width: 300px;
+    margin-right: 10px;
+}
+
+/* Notices */
+.notice.notice-success {
+    border-left-color: #27ae60;
+}
+
+.notice.notice-error {
+    border-left-color: #e74c3c;
+}
+
+/* Responsive Design */
+@media screen and (max-width: 782px) {
+    .return-request-details .form-table th {
+        width: auto;
+        display: block;
+        background-color: transparent;
+        border-bottom: none;
+        padding-bottom: 5px;
+    }
+    
+    .return-request-details .form-table td {
+        display: block;
+        border-bottom: 1px solid #e1e1e1;
+        padding-top: 5px;
+        padding-bottom: 15px;
+    }
+    
+    .return-requests-stats {
+        flex-direction: column;
+        gap: 10px;
+    }
+    
+    .search-box input[type="search"] {
+        width: 100%;
+        margin-bottom: 10px;
+    }
+}
+
+/* Loading Animation */
+.loading-spinner {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #f3f3f3;
+    border-top: 3px solid #007cba;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 10px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Admin Table Actions */
+.row-actions {
+    visibility: hidden;
+}
+
+.wp-list-table tr:hover .row-actions {
+    visibility: visible;
+}
+
+.row-actions span {
+    display: inline-block;
+    margin-right: 10px;
+}
+
+.row-actions a {
+    color: #007cba;
+    text-decoration: none;
+}
+
+.row-actions a:hover {
+    text-decoration: underline;
+}
+
+/* Quick Edit */
+.quick-edit-row {
+    background-color: #f9f9f9;
+}
+
+.quick-edit-row .form-table th {
+    width: 150px;
+    font-weight: normal;
+}
+
+/* Bulk Actions */
+.tablenav .actions {
+    margin-bottom: 10px;
+}
+
+/* Email Template Preview */
+.email-preview {
+    border: 1px solid #ddd;
+    padding: 20px;
+    background-color: #fff;
+    margin: 20px 0;
+    border-radius: 4px;
+}
+
+.email-preview h4 {
+    margin-top: 0;
+    color: #23282d;
+}
+
+/* File Type Icons */
+.file-item::before {
+    content: "📎";
+    margin-right: 8px;
+    font-size: 16px;
+}
+
+.file-item[data-type*="image"]::before {
+    content: "🖼️";
+}
+
+.file-item[data-type*="video"]::before {
+    content: "🎥";
+}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,314 @@
+/* Return Button Plugin Frontend Styles */
+
+/* Return Request Button */
+.woocommerce-MyAccount-content .woocommerce-orders-table .button.return-request-btn {
+    background-color: #e74c3c;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    text-decoration: none;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.woocommerce-MyAccount-content .woocommerce-orders-table .button.return-request-btn:hover {
+    background-color: #c0392b;
+    color: white;
+    text-decoration: none;
+}
+
+/* Modal Styles */
+.return-modal {
+    position: fixed;
+    z-index: 10000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.return-modal-content {
+    background-color: #ffffff;
+    margin: auto;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    width: 90%;
+    max-width: 600px;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+}
+
+.return-modal-header {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-bottom: 1px solid #dee2e6;
+    border-radius: 8px 8px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.return-modal-header h3 {
+    margin: 0;
+    color: #343a40;
+    font-size: 1.5em;
+    font-weight: 600;
+}
+
+.return-modal-close {
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    color: #6c757d;
+    transition: color 0.3s ease;
+}
+
+.return-modal-close:hover {
+    color: #343a40;
+}
+
+/* Form Styles */
+#return-request-form {
+    padding: 30px;
+}
+
+.return-form-row {
+    margin-bottom: 20px;
+}
+
+.return-form-row label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #343a40;
+    font-size: 14px;
+}
+
+.return-form-row input[type="text"],
+.return-form-row input[type="email"],
+.return-form-row input[type="tel"],
+.return-form-row textarea,
+.return-form-row input[type="file"] {
+    width: 100%;
+    padding: 12px;
+    border: 2px solid #e9ecef;
+    border-radius: 6px;
+    font-size: 14px;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    background-color: #ffffff;
+}
+
+.return-form-row input[type="text"]:focus,
+.return-form-row input[type="email"]:focus,
+.return-form-row input[type="tel"]:focus,
+.return-form-row textarea:focus,
+.return-form-row input[type="file"]:focus {
+    outline: none;
+    border-color: #007cba;
+    box-shadow: 0 0 0 3px rgba(0, 124, 186, 0.1);
+}
+
+.return-form-row textarea {
+    resize: vertical;
+    min-height: 100px;
+}
+
+.return-form-row small {
+    display: block;
+    margin-top: 5px;
+    color: #6c757d;
+    font-size: 12px;
+}
+
+.return-form-row input[type="file"] {
+    padding: 8px;
+    background-color: #f8f9fa;
+}
+
+/* Form Actions */
+.return-form-actions {
+    display: flex;
+    gap: 15px;
+    justify-content: flex-end;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid #dee2e6;
+}
+
+.return-btn-cancel,
+.return-btn-submit {
+    padding: 12px 24px;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    display: inline-block;
+    text-align: center;
+}
+
+.return-btn-cancel {
+    background-color: #6c757d;
+    color: white;
+}
+
+.return-btn-cancel:hover {
+    background-color: #5a6268;
+    color: white;
+}
+
+.return-btn-submit {
+    background-color: #28a745;
+    color: white;
+}
+
+.return-btn-submit:hover {
+    background-color: #218838;
+}
+
+.return-btn-submit:disabled {
+    background-color: #6c757d;
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* Loading State */
+.return-form-loading {
+    position: relative;
+}
+
+.return-form-loading::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.return-form-loading::before {
+    content: "Processing...";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #007cba;
+    color: white;
+    padding: 10px 20px;
+    border-radius: 4px;
+    z-index: 1;
+}
+
+/* Success/Error Messages */
+.return-message {
+    padding: 15px;
+    margin-bottom: 20px;
+    border-radius: 6px;
+    font-weight: 600;
+}
+
+.return-message.success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.return-message.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+/* Required Field Indicator */
+.return-form-row label:after {
+    content: " *";
+    color: #e74c3c;
+    font-weight: bold;
+}
+
+.return-form-row label[for="customer_whatsapp"]:after,
+.return-form-row label[for="return_files"]:after {
+    content: "";
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .return-modal-content {
+        width: 95%;
+        margin: 10px;
+    }
+    
+    .return-modal-header {
+        padding: 15px;
+    }
+    
+    #return-request-form {
+        padding: 20px;
+    }
+    
+    .return-form-actions {
+        flex-direction: column;
+    }
+    
+    .return-btn-cancel,
+    .return-btn-submit {
+        width: 100%;
+        margin-bottom: 10px;
+    }
+}
+
+@media (max-width: 480px) {
+    .return-modal-content {
+        width: 98%;
+        margin: 5px;
+    }
+    
+    .return-modal-header h3 {
+        font-size: 1.3em;
+    }
+    
+    #return-request-form {
+        padding: 15px;
+    }
+}
+
+/* File Upload Styling */
+.return-form-row input[type="file"] {
+    border: 2px dashed #e9ecef;
+    background-color: #f8f9fa;
+    cursor: pointer;
+}
+
+.return-form-row input[type="file"]:hover {
+    border-color: #007cba;
+    background-color: #ffffff;
+}
+
+/* Animation for modal */
+@keyframes modalFadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.return-modal-content {
+    animation: modalFadeIn 0.3s ease-out;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,349 @@
+jQuery(document).ready(function($) {
+    'use strict';
+
+    // Admin dashboard functionality
+    
+    // Quick status update
+    $('.quick-status-update').on('change', function() {
+        const requestId = $(this).data('request-id');
+        const newStatus = $(this).val();
+        const row = $(this).closest('tr');
+        
+        if (!requestId || !newStatus) {
+            return;
+        }
+        
+        // Show loading
+        const loadingSpinner = '<span class="loading-spinner"></span>';
+        row.find('.status-column').html(loadingSpinner + 'Updating...');
+        
+        // AJAX request to update status
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            data: {
+                action: 'update_return_request_status',
+                request_id: requestId,
+                new_status: newStatus,
+                nonce: return_admin_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    // Update status display
+                    const statusHtml = '<span class="status-' + newStatus + '">' + 
+                                     newStatus.charAt(0).toUpperCase() + newStatus.slice(1) + 
+                                     '</span>';
+                    row.find('.status-column').html(statusHtml);
+                    
+                    // Show success message
+                    showAdminNotice('success', 'Status updated successfully!');
+                } else {
+                    showAdminNotice('error', response.data.message || 'Failed to update status.');
+                    // Reload to reset the form
+                    location.reload();
+                }
+            },
+            error: function() {
+                showAdminNotice('error', 'An error occurred while updating status.');
+                location.reload();
+            }
+        });
+    });
+    
+    // Bulk actions
+    $('#doaction, #doaction2').on('click', function(e) {
+        const action = $(this).siblings('select').val();
+        const checkedItems = $('input[name="return_request[]"]:checked');
+        
+        if (action === '-1' || checkedItems.length === 0) {
+            return;
+        }
+        
+        e.preventDefault();
+        
+        if (!confirm('Are you sure you want to perform this action on ' + checkedItems.length + ' item(s)?')) {
+            return;
+        }
+        
+        const requestIds = [];
+        checkedItems.each(function() {
+            requestIds.push($(this).val());
+        });
+        
+        // Show loading
+        $(this).prop('disabled', true).after('<span class="loading-spinner"></span>');
+        
+        // AJAX request for bulk action
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            data: {
+                action: 'bulk_update_return_requests',
+                bulk_action: action,
+                request_ids: requestIds,
+                nonce: return_admin_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    showAdminNotice('success', response.data.message);
+                    setTimeout(function() {
+                        location.reload();
+                    }, 1500);
+                } else {
+                    showAdminNotice('error', response.data.message || 'Bulk action failed.');
+                    location.reload();
+                }
+            },
+            error: function() {
+                showAdminNotice('error', 'An error occurred during bulk action.');
+                location.reload();
+            }
+        });
+    });
+    
+    // Search functionality
+    $('#return-requests-search').on('input', debounce(function() {
+        const searchTerm = $(this).val();
+        filterTable(searchTerm);
+    }, 300));
+    
+    // Filter by status
+    $('#status-filter').on('change', function() {
+        const status = $(this).val();
+        const currentUrl = new URL(window.location.href);
+        
+        if (status) {
+            currentUrl.searchParams.set('status', status);
+        } else {
+            currentUrl.searchParams.delete('status');
+        }
+        
+        window.location.href = currentUrl.toString();
+    });
+    
+    // Table row highlighting
+    $('.wp-list-table tbody tr').on('mouseenter', function() {
+        $(this).addClass('hover-highlight');
+    }).on('mouseleave', function() {
+        $(this).removeClass('hover-highlight');
+    });
+    
+    // File preview in modal
+    $('.file-preview-link').on('click', function(e) {
+        e.preventDefault();
+        
+        const fileUrl = $(this).attr('href');
+        const fileName = $(this).text();
+        const fileType = $(this).data('file-type');
+        
+        showFilePreview(fileUrl, fileName, fileType);
+    });
+    
+    // Settings form validation
+    $('#return-button-settings-form').on('submit', function(e) {
+        const returnPeriod = parseInt($('#return_period_days').val());
+        const gracePeriod = parseInt($('#grace_period_days').val());
+        
+        if (returnPeriod < 1 || returnPeriod > 365) {
+            e.preventDefault();
+            showAdminNotice('error', 'Return period must be between 1 and 365 days.');
+            return;
+        }
+        
+        if (gracePeriod < 1 || gracePeriod > 365) {
+            e.preventDefault();
+            showAdminNotice('error', 'Grace period must be between 1 and 365 days.');
+            return;
+        }
+    });
+    
+    // Auto-refresh stats
+    setInterval(function() {
+        updateDashboardStats();
+    }, 60000); // Refresh every minute
+    
+    // Functions
+    
+    function showAdminNotice(type, message) {
+        // Remove existing notices
+        $('.admin-notice-custom').remove();
+        
+        const noticeClass = type === 'success' ? 'notice-success' : 'notice-error';
+        const noticeHtml = '<div class="notice ' + noticeClass + ' is-dismissible admin-notice-custom">' +
+                          '<p>' + message + '</p>' +
+                          '<button type="button" class="notice-dismiss">' +
+                          '<span class="screen-reader-text">Dismiss this notice.</span>' +
+                          '</button>' +
+                          '</div>';
+        
+        $('.wrap h1').after(noticeHtml);
+        
+        // Auto-dismiss after 5 seconds
+        setTimeout(function() {
+            $('.admin-notice-custom').fadeOut();
+        }, 5000);
+    }
+    
+    function filterTable(searchTerm) {
+        const tableRows = $('.wp-list-table tbody tr');
+        
+        if (!searchTerm) {
+            tableRows.show();
+            return;
+        }
+        
+        tableRows.each(function() {
+            const rowText = $(this).text().toLowerCase();
+            const shouldShow = rowText.includes(searchTerm.toLowerCase());
+            
+            if (shouldShow) {
+                $(this).show();
+            } else {
+                $(this).hide();
+            }
+        });
+    }
+    
+    function showFilePreview(fileUrl, fileName, fileType) {
+        let previewContent = '';
+        
+        if (fileType && fileType.startsWith('image/')) {
+            previewContent = '<img src="' + fileUrl + '" alt="' + fileName + '" style="max-width: 100%; height: auto;">';
+        } else if (fileType && fileType.startsWith('video/')) {
+            previewContent = '<video controls style="max-width: 100%; height: auto;">' +
+                           '<source src="' + fileUrl + '" type="' + fileType + '">' +
+                           'Your browser does not support the video tag.' +
+                           '</video>';
+        } else {
+            previewContent = '<p>Preview not available. <a href="' + fileUrl + '" target="_blank">Download file</a></p>';
+        }
+        
+        const modalHtml = '<div id="file-preview-modal" class="file-preview-modal">' +
+                         '<div class="file-preview-content">' +
+                         '<div class="file-preview-header">' +
+                         '<h3>' + fileName + '</h3>' +
+                         '<span class="file-preview-close">&times;</span>' +
+                         '</div>' +
+                         '<div class="file-preview-body">' + previewContent + '</div>' +
+                         '</div>' +
+                         '</div>';
+        
+        $('body').append(modalHtml);
+        
+        // Show modal
+        $('#file-preview-modal').fadeIn();
+        
+        // Close modal events
+        $('.file-preview-close, #file-preview-modal').on('click', function(e) {
+            if (e.target === this) {
+                $('#file-preview-modal').fadeOut(function() {
+                    $(this).remove();
+                });
+            }
+        });
+    }
+    
+    function updateDashboardStats() {
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            data: {
+                action: 'get_return_requests_stats',
+                nonce: return_admin_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    const stats = response.data;
+                    $('.stat-total .stat-number').text(stats.total);
+                    $('.stat-pending .stat-number').text(stats.pending);
+                    $('.stat-processing .stat-number').text(stats.processing);
+                    $('.stat-completed .stat-number').text(stats.completed);
+                }
+            }
+        });
+    }
+    
+    function debounce(func, wait) {
+        let timeout;
+        return function executedFunction(...args) {
+            const later = () => {
+                clearTimeout(timeout);
+                func(...args);
+            };
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+        };
+    }
+    
+    // Initialize tooltips
+    $('[data-tooltip]').each(function() {
+        $(this).attr('title', $(this).data('tooltip'));
+    });
+    
+    // Status change confirmation
+    $('select[name="new_status"]').on('change', function() {
+        const currentStatus = $(this).data('current-status');
+        const newStatus = $(this).val();
+        
+        if (currentStatus === 'completed' && newStatus !== 'completed') {
+            if (!confirm('Are you sure you want to change status from completed? This action should be carefully considered.')) {
+                $(this).val(currentStatus);
+            }
+        }
+    });
+    
+    // Add custom CSS for admin enhancements
+    $('<style>')
+        .prop('type', 'text/css')
+        .html(`
+            .hover-highlight {
+                background-color: #f0f8ff !important;
+            }
+            .file-preview-modal {
+                position: fixed;
+                z-index: 10000;
+                left: 0;
+                top: 0;
+                width: 100%;
+                height: 100%;
+                background-color: rgba(0, 0, 0, 0.8);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+            .file-preview-content {
+                background-color: white;
+                padding: 0;
+                border-radius: 8px;
+                max-width: 90%;
+                max-height: 90%;
+                overflow: auto;
+            }
+            .file-preview-header {
+                padding: 20px;
+                border-bottom: 1px solid #ddd;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+            .file-preview-header h3 {
+                margin: 0;
+            }
+            .file-preview-close {
+                font-size: 24px;
+                cursor: pointer;
+                color: #666;
+            }
+            .file-preview-close:hover {
+                color: #000;
+            }
+            .file-preview-body {
+                padding: 20px;
+                text-align: center;
+            }
+            .admin-notice-custom {
+                margin: 20px 0;
+            }
+        `)
+        .appendTo('head');
+});

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,316 @@
+jQuery(document).ready(function($) {
+    'use strict';
+
+    // Return Request Modal functionality
+    const modal = $('#return-request-modal');
+    const form = $('#return-request-form');
+    const closeModal = $('.return-modal-close, .return-btn-cancel');
+
+    // Open modal when return request button is clicked
+    $(document).on('click', '.return-request-btn', function(e) {
+        e.preventDefault();
+        
+        const orderId = $(this).data('order-id');
+        const orderNumber = $(this).data('order-number');
+        
+        // Set order ID in the form
+        $('#order_id').val(orderId);
+        
+        // Reset form
+        form[0].reset();
+        $('.return-message').remove();
+        
+        // Pre-fill user data if available
+        prefillUserData();
+        
+        // Show modal
+        modal.fadeIn(300);
+        
+        // Focus on first field
+        setTimeout(function() {
+            $('#customer_name').focus();
+        }, 350);
+    });
+
+    // Close modal
+    closeModal.on('click', function(e) {
+        e.preventDefault();
+        modal.fadeOut(300);
+    });
+
+    // Close modal when clicking outside
+    modal.on('click', function(e) {
+        if (e.target === this) {
+            modal.fadeOut(300);
+        }
+    });
+
+    // Close modal on escape key
+    $(document).on('keydown', function(e) {
+        if (e.keyCode === 27 && modal.is(':visible')) {
+            modal.fadeOut(300);
+        }
+    });
+
+    // Auto-fill WhatsApp if same as phone
+    $('#customer_phone').on('blur', function() {
+        const phoneNumber = $(this).val();
+        const whatsappField = $('#customer_whatsapp');
+        
+        if (phoneNumber && !whatsappField.val()) {
+            whatsappField.attr('placeholder', 'Same as phone: ' + phoneNumber);
+        }
+    });
+
+    // Form submission
+    form.on('submit', function(e) {
+        e.preventDefault();
+        
+        // Remove previous messages
+        $('.return-message').remove();
+        
+        // Validate form
+        if (!validateForm()) {
+            return;
+        }
+        
+        // Prepare form data
+        const formData = new FormData(this);
+        
+        // Add loading state
+        form.addClass('return-form-loading');
+        $('.return-btn-submit').prop('disabled', true).text('Submitting...');
+        
+        // AJAX request
+        $.ajax({
+            url: return_button_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function(response) {
+                if (response.success) {
+                    showMessage('success', response.data.message);
+                    
+                    // Close modal after delay
+                    setTimeout(function() {
+                        modal.fadeOut(300);
+                        // Reload page to update button state
+                        location.reload();
+                    }, 2000);
+                } else {
+                    showMessage('error', response.data.message || return_button_ajax.messages.error);
+                }
+            },
+            error: function(xhr, status, error) {
+                console.error('AJAX Error:', error);
+                showMessage('error', return_button_ajax.messages.error);
+            },
+            complete: function() {
+                // Remove loading state
+                form.removeClass('return-form-loading');
+                $('.return-btn-submit').prop('disabled', false).text('Submit Request');
+            }
+        });
+    });
+
+    // Form validation
+    function validateForm() {
+        let isValid = true;
+        const requiredFields = ['customer_name', 'customer_email', 'customer_phone', 'return_reason'];
+        
+        // Remove previous error styling
+        $('.form-field-error').removeClass('form-field-error');
+        
+        requiredFields.forEach(function(fieldName) {
+            const field = $('#' + fieldName);
+            const value = field.val().trim();
+            
+            if (!value) {
+                field.addClass('form-field-error');
+                isValid = false;
+            }
+        });
+        
+        // Email validation
+        const email = $('#customer_email').val().trim();
+        if (email && !isValidEmail(email)) {
+            $('#customer_email').addClass('form-field-error');
+            showMessage('error', 'Please enter a valid email address.');
+            isValid = false;
+        }
+        
+        // File validation
+        const fileInput = $('#return_files')[0];
+        if (fileInput.files.length > 0) {
+            if (!validateFiles(fileInput.files)) {
+                isValid = false;
+            }
+        }
+        
+        if (!isValid && !$('.return-message').length) {
+            showMessage('error', 'Please fill all required fields correctly.');
+        }
+        
+        return isValid;
+    }
+
+    // Email validation
+    function isValidEmail(email) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailRegex.test(email);
+    }
+
+    // File validation
+    function validateFiles(files) {
+        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'video/mp4'];
+        const maxSize = 10 * 1024 * 1024; // 10MB
+        
+        for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            
+            // Check file type
+            if (!allowedTypes.includes(file.type)) {
+                showMessage('error', 'Invalid file type. Only JPG, JPEG, PNG images and MP4 videos are allowed.');
+                return false;
+            }
+            
+            // Check file size
+            if (file.size > maxSize) {
+                showMessage('error', 'File size too large. Maximum allowed size is 10MB per file.');
+                return false;
+            }
+        }
+        
+        return true;
+    }
+
+    // Show message
+    function showMessage(type, message) {
+        $('.return-message').remove();
+        
+        const messageHtml = '<div class="return-message ' + type + '">' + message + '</div>';
+        form.prepend(messageHtml);
+        
+        // Scroll to top of form
+        form.scrollTop(0);
+    }
+
+    // Pre-fill user data
+    function prefillUserData() {
+        // Get user data from WooCommerce if available
+        const userEmail = $('.woocommerce-MyAccount-content .woocommerce-Address-title').siblings('address').find('a[href^="mailto:"]').text();
+        
+        if (userEmail) {
+            $('#customer_email').val(userEmail);
+        }
+        
+        // You can add more prefill logic here based on available user data
+    }
+
+    // File input styling and preview
+    $('#return_files').on('change', function() {
+        const files = this.files;
+        const fileList = $('.file-preview-list');
+        
+        // Remove existing preview
+        fileList.remove();
+        
+        if (files.length > 0) {
+            let previewHtml = '<div class="file-preview-list"><strong>Selected files:</strong><ul>';
+            
+            for (let i = 0; i < files.length; i++) {
+                const file = files[i];
+                const fileSize = formatFileSize(file.size);
+                previewHtml += '<li>' + file.name + ' (' + fileSize + ')</li>';
+            }
+            
+            previewHtml += '</ul></div>';
+            $(this).parent().append(previewHtml);
+        }
+    });
+
+    // Format file size
+    function formatFileSize(bytes) {
+        if (bytes === 0) return '0 Bytes';
+        
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    // Add CSS for form field errors
+    $('<style>')
+        .prop('type', 'text/css')
+        .html(`
+            .form-field-error {
+                border-color: #e74c3c !important;
+                box-shadow: 0 0 0 3px rgba(231, 76, 60, 0.1) !important;
+            }
+            .file-preview-list {
+                margin-top: 10px;
+                padding: 10px;
+                background-color: #f8f9fa;
+                border-radius: 4px;
+                font-size: 12px;
+            }
+            .file-preview-list ul {
+                margin: 5px 0 0 0;
+                padding-left: 20px;
+            }
+            .file-preview-list li {
+                margin: 2px 0;
+                color: #6c757d;
+            }
+        `)
+        .appendTo('head');
+
+    // Security enhancements
+    // Prevent XSS in form inputs
+    $('input[type="text"], input[type="email"], input[type="tel"], textarea').on('input', function() {
+        const value = $(this).val();
+        // Remove potentially dangerous characters
+        const sanitized = value.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+        $(this).val(sanitized);
+    });
+
+    // Phone number formatting
+    $('#customer_phone, #customer_whatsapp').on('input', function() {
+        let value = $(this).val().replace(/\D/g, ''); // Remove non-digits
+        
+        // Limit to reasonable phone number length
+        if (value.length > 15) {
+            value = value.substring(0, 15);
+        }
+        
+        $(this).val(value);
+    });
+
+    // Character limit for return reason
+    $('#return_reason').on('input', function() {
+        const maxLength = 1000;
+        const currentLength = $(this).val().length;
+        
+        if (currentLength > maxLength) {
+            $(this).val($(this).val().substring(0, maxLength));
+        }
+        
+        // Show character count
+        let charCounter = $(this).siblings('.char-counter');
+        if (charCounter.length === 0) {
+            charCounter = $('<small class="char-counter"></small>');
+            $(this).after(charCounter);
+        }
+        
+        const remaining = maxLength - $(this).val().length;
+        charCounter.text(remaining + ' characters remaining');
+        
+        if (remaining < 50) {
+            charCounter.css('color', '#e74c3c');
+        } else {
+            charCounter.css('color', '#6c757d');
+        }
+    });
+});

--- a/includes/class-return-request-admin.php
+++ b/includes/class-return-request-admin.php
@@ -1,0 +1,362 @@
+<?php
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Include WP List Table class
+if (!class_exists('WP_List_Table')) {
+    require_once(ABSPATH . 'wp-admin/includes/class-wp-list-table.php');
+}
+
+class Return_Request_Admin {
+    
+    public function __construct() {
+        add_action('admin_menu', array($this, 'add_admin_menu'));
+        add_action('admin_init', array($this, 'handle_admin_actions'));
+    }
+    
+    /**
+     * Add admin menu
+     */
+    public function add_admin_menu() {
+        add_menu_page(
+            __('Return Requests', 'return-button'),
+            __('Return Requests', 'return-button'),
+            'manage_woocommerce',
+            'return-requests',
+            array($this, 'admin_page'),
+            'dashicons-undo',
+            30
+        );
+        
+        add_submenu_page(
+            'return-requests',
+            __('All Return Requests', 'return-button'),
+            __('All Requests', 'return-button'),
+            'manage_woocommerce',
+            'return-requests',
+            array($this, 'admin_page')
+        );
+        
+        add_submenu_page(
+            'return-requests',
+            __('Settings', 'return-button'),
+            __('Settings', 'return-button'),
+            'manage_woocommerce',
+            'return-requests-settings',
+            array($this, 'settings_page')
+        );
+    }
+    
+    /**
+     * Admin page display
+     */
+    public function admin_page() {
+        $action = isset($_GET['action']) ? sanitize_text_field($_GET['action']) : '';
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        
+        if ($action === 'view' && $id) {
+            $this->view_request_page($id);
+        } else {
+            $this->list_requests_page();
+        }
+    }
+    
+    /**
+     * List requests page
+     */
+    private function list_requests_page() {
+        $list_table = new Return_Request_List_Table();
+        $list_table->prepare_items();
+        
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Return Requests', 'return-button'); ?></h1>
+            
+            <form method="get">
+                <input type="hidden" name="page" value="return-requests">
+                <?php $list_table->search_box(__('Search Requests', 'return-button'), 'search_id'); ?>
+            </form>
+            
+            <form method="post">
+                <?php $list_table->display(); ?>
+            </form>
+        </div>
+        <?php
+    }
+    
+    /**
+     * View single request page
+     */
+    private function view_request_page($id) {
+        $request = Return_Request_Database::get_return_request($id);
+        if (!$request) {
+            echo '<div class="notice notice-error"><p>' . __('Return request not found.', 'return-button') . '</p></div>';
+            return;
+        }
+        
+        $order = wc_get_order($request->order_id);
+        
+        ?>
+        <div class="wrap">
+            <h1><?php printf(__('Return Request #%d', 'return-button'), $id); ?></h1>
+            
+            <div class="return-request-details">
+                <table class="form-table">
+                    <tr>
+                        <th><?php _e('Order Number', 'return-button'); ?></th>
+                        <td>
+                            <a href="<?php echo admin_url('post.php?post=' . $request->order_id . '&action=edit'); ?>">
+                                #<?php echo $order ? $order->get_order_number() : $request->order_id; ?>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><?php _e('Customer Name', 'return-button'); ?></th>
+                        <td><?php echo esc_html($request->customer_name); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php _e('Customer Email', 'return-button'); ?></th>
+                        <td><a href="mailto:<?php echo esc_attr($request->customer_email); ?>"><?php echo esc_html($request->customer_email); ?></a></td>
+                    </tr>
+                    <tr>
+                        <th><?php _e('Phone Number', 'return-button'); ?></th>
+                        <td><?php echo esc_html($request->customer_phone); ?></td>
+                    </tr>
+                    <?php if (!empty($request->customer_whatsapp)): ?>
+                    <tr>
+                        <th><?php _e('WhatsApp Number', 'return-button'); ?></th>
+                        <td><?php echo esc_html($request->customer_whatsapp); ?></td>
+                    </tr>
+                    <?php endif; ?>
+                    <tr>
+                        <th><?php _e('Return Reason', 'return-button'); ?></th>
+                        <td><?php echo nl2br(esc_html($request->return_reason)); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php _e('Request Date', 'return-button'); ?></th>
+                        <td><?php echo date('Y-m-d H:i:s', strtotime($request->request_date)); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php _e('Status', 'return-button'); ?></th>
+                        <td>
+                            <span class="status-<?php echo esc_attr($request->status); ?>">
+                                <?php echo ucfirst($request->status); ?>
+                            </span>
+                        </td>
+                    </tr>
+                </table>
+                
+                <?php if (!empty($request->uploaded_files)): ?>
+                <h3><?php _e('Uploaded Files', 'return-button'); ?></h3>
+                <div class="uploaded-files">
+                    <?php foreach ($request->uploaded_files as $file): ?>
+                        <div class="file-item">
+                            <a href="<?php echo esc_url($file['file_url']); ?>" target="_blank">
+                                <?php echo esc_html($file['original_name']); ?>
+                            </a>
+                            <span class="file-size">(<?php echo size_format($file['file_size']); ?>)</span>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <?php endif; ?>
+                
+                <h3><?php _e('Update Status', 'return-button'); ?></h3>
+                <form method="post" action="">
+                    <table class="form-table">
+                        <tr>
+                            <th><?php _e('Status', 'return-button'); ?></th>
+                            <td>
+                                <select name="new_status">
+                                    <option value="pending" <?php selected($request->status, 'pending'); ?>><?php _e('Pending', 'return-button'); ?></option>
+                                    <option value="processing" <?php selected($request->status, 'processing'); ?>><?php _e('Processing', 'return-button'); ?></option>
+                                    <option value="completed" <?php selected($request->status, 'completed'); ?>><?php _e('Completed', 'return-button'); ?></option>
+                                    <option value="cancelled_by_admin" <?php selected($request->status, 'cancelled_by_admin'); ?>><?php _e('Cancelled by Admin', 'return-button'); ?></option>
+                                    <option value="cancelled_by_user" <?php selected($request->status, 'cancelled_by_user'); ?>><?php _e('Cancelled by User', 'return-button'); ?></option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th><?php _e('Admin Notes', 'return-button'); ?></th>
+                            <td>
+                                <textarea name="admin_notes" rows="4" cols="50"><?php echo esc_textarea($request->admin_notes); ?></textarea>
+                            </td>
+                        </tr>
+                    </table>
+                    
+                    <?php wp_nonce_field('update_return_request', 'update_nonce'); ?>
+                    <input type="hidden" name="request_id" value="<?php echo $id; ?>">
+                    <input type="hidden" name="action" value="update_status">
+                    
+                    <p class="submit">
+                        <input type="submit" class="button-primary" value="<?php _e('Update Status', 'return-button'); ?>">
+                        <a href="<?php echo admin_url('admin.php?page=return-requests'); ?>" class="button"><?php _e('Back to List', 'return-button'); ?></a>
+                    </p>
+                </form>
+            </div>
+        </div>
+        <?php
+    }
+    
+    /**
+     * Settings page
+     */
+    public function settings_page() {
+        if (isset($_POST['submit'])) {
+            check_admin_referer('return_button_settings', 'settings_nonce');
+            
+            update_option('return_button_return_period_days', intval($_POST['return_period_days']));
+            update_option('return_button_grace_period_days', intval($_POST['grace_period_days']));
+            
+            echo '<div class="notice notice-success"><p>' . __('Settings saved successfully!', 'return-button') . '</p></div>';
+        }
+        
+        $return_period_days = get_option('return_button_return_period_days', 10);
+        $grace_period_days = get_option('return_button_grace_period_days', 10);
+        
+        ?>
+        <div class="wrap">
+            <h1><?php _e('Return Request Settings', 'return-button'); ?></h1>
+            
+            <form method="post" action="">
+                <table class="form-table">
+                    <tr>
+                        <th scope="row"><?php _e('Return Period (Days)', 'return-button'); ?></th>
+                        <td>
+                            <input type="number" name="return_period_days" value="<?php echo esc_attr($return_period_days); ?>" min="1" max="365">
+                            <p class="description"><?php _e('Number of days after order completion when return request becomes available.', 'return-button'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php _e('Grace Period (Days)', 'return-button'); ?></th>
+                        <td>
+                            <input type="number" name="grace_period_days" value="<?php echo esc_attr($grace_period_days); ?>" min="1" max="365">
+                            <p class="description"><?php _e('Number of days the return request button remains available after the return period starts.', 'return-button'); ?></p>
+                        </td>
+                    </tr>
+                </table>
+                
+                <?php wp_nonce_field('return_button_settings', 'settings_nonce'); ?>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+    
+    /**
+     * Handle admin actions
+     */
+    public function handle_admin_actions() {
+        if (isset($_POST['action']) && $_POST['action'] === 'update_status') {
+            if (!wp_verify_nonce($_POST['update_nonce'], 'update_return_request')) {
+                wp_die(__('Security check failed', 'return-button'));
+            }
+            
+            $request_id = intval($_POST['request_id']);
+            $new_status = sanitize_text_field($_POST['new_status']);
+            $admin_notes = sanitize_textarea_field($_POST['admin_notes']);
+            
+            if (Return_Request_Database::update_status($request_id, $new_status, $admin_notes)) {
+                // Send email notification to customer
+                Return_Request_Email::send_status_update($request_id, $new_status, $admin_notes);
+                
+                add_action('admin_notices', function() {
+                    echo '<div class="notice notice-success"><p>' . __('Status updated successfully!', 'return-button') . '</p></div>';
+                });
+            } else {
+                add_action('admin_notices', function() {
+                    echo '<div class="notice notice-error"><p>' . __('Failed to update status.', 'return-button') . '</p></div>';
+                });
+            }
+        }
+    }
+}
+
+/**
+ * WP List Table for Return Requests
+ */
+class Return_Request_List_Table extends WP_List_Table {
+    
+    public function __construct() {
+        parent::__construct(array(
+            'singular' => 'return_request',
+            'plural' => 'return_requests',
+            'ajax' => false
+        ));
+    }
+    
+    public function get_columns() {
+        return array(
+            'cb' => '<input type="checkbox" />',
+            'id' => __('ID', 'return-button'),
+            'order_id' => __('Order', 'return-button'),
+            'customer_name' => __('Customer', 'return-button'),
+            'customer_email' => __('Email', 'return-button'),
+            'status' => __('Status', 'return-button'),
+            'request_date' => __('Date', 'return-button'),
+            'actions' => __('Actions', 'return-button')
+        );
+    }
+    
+    public function get_sortable_columns() {
+        return array(
+            'id' => array('id', false),
+            'order_id' => array('order_id', false),
+            'customer_name' => array('customer_name', false),
+            'status' => array('status', false),
+            'request_date' => array('request_date', true)
+        );
+    }
+    
+    public function prepare_items() {
+        $columns = $this->get_columns();
+        $hidden = array();
+        $sortable = $this->get_sortable_columns();
+        
+        $this->_column_headers = array($columns, $hidden, $sortable);
+        
+        $per_page = 20;
+        $current_page = $this->get_pagenum();
+        $offset = ($current_page - 1) * $per_page;
+        
+        $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
+        
+        $this->items = Return_Request_Database::get_all_return_requests($status_filter, $per_page, $offset);
+        $total_items = Return_Request_Database::get_total_count($status_filter);
+        
+        $this->set_pagination_args(array(
+            'total_items' => $total_items,
+            'per_page' => $per_page,
+            'total_pages' => ceil($total_items / $per_page)
+        ));
+    }
+    
+    public function column_default($item, $column_name) {
+        switch ($column_name) {
+            case 'id':
+                return $item->id;
+            case 'order_id':
+                $order = wc_get_order($item->order_id);
+                return '<a href="' . admin_url('post.php?post=' . $item->order_id . '&action=edit') . '">#' . 
+                       ($order ? $order->get_order_number() : $item->order_id) . '</a>';
+            case 'customer_name':
+                return esc_html($item->customer_name);
+            case 'customer_email':
+                return '<a href="mailto:' . esc_attr($item->customer_email) . '">' . esc_html($item->customer_email) . '</a>';
+            case 'status':
+                return '<span class="status-' . esc_attr($item->status) . '">' . ucfirst($item->status) . '</span>';
+            case 'request_date':
+                return date('Y-m-d H:i', strtotime($item->request_date));
+            case 'actions':
+                return '<a href="' . admin_url('admin.php?page=return-requests&action=view&id=' . $item->id) . '" class="button button-small">' . __('View', 'return-button') . '</a>';
+            default:
+                return '';
+        }
+    }
+    
+    public function column_cb($item) {
+        return sprintf('<input type="checkbox" name="return_request[]" value="%s" />', $item->id);
+    }
+}

--- a/includes/class-return-request-database.php
+++ b/includes/class-return-request-database.php
@@ -1,0 +1,180 @@
+<?php
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Return_Request_Database {
+    
+    const TABLE_NAME = 'return_requests';
+    
+    /**
+     * Create the return requests table
+     */
+    public static function create_table() {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $charset_collate = $wpdb->get_charset_collate();
+        
+        $sql = "CREATE TABLE $table_name (
+            id int(11) NOT NULL AUTO_INCREMENT,
+            order_id int(11) NOT NULL,
+            user_id int(11) NOT NULL,
+            customer_name varchar(255) NOT NULL,
+            customer_email varchar(255) NOT NULL,
+            customer_phone varchar(20) NOT NULL,
+            customer_whatsapp varchar(20) DEFAULT NULL,
+            return_reason text NOT NULL,
+            uploaded_files text DEFAULT NULL,
+            status varchar(50) DEFAULT 'pending',
+            request_date datetime DEFAULT CURRENT_TIMESTAMP,
+            updated_date datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            admin_notes text DEFAULT NULL,
+            PRIMARY KEY (id),
+            KEY order_id (order_id),
+            KEY user_id (user_id),
+            KEY status (status)
+        ) $charset_collate;";
+        
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        dbDelta($sql);
+    }
+    
+    /**
+     * Insert a new return request
+     */
+    public static function insert_return_request($data) {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $result = $wpdb->insert(
+            $table_name,
+            array(
+                'order_id' => $data['order_id'],
+                'user_id' => $data['user_id'],
+                'customer_name' => sanitize_text_field($data['customer_name']),
+                'customer_email' => sanitize_email($data['customer_email']),
+                'customer_phone' => sanitize_text_field($data['customer_phone']),
+                'customer_whatsapp' => sanitize_text_field($data['customer_whatsapp']),
+                'return_reason' => sanitize_textarea_field($data['return_reason']),
+                'uploaded_files' => maybe_serialize($data['uploaded_files']),
+                'status' => 'pending'
+            ),
+            array(
+                '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s'
+            )
+        );
+        
+        return $result !== false ? $wpdb->insert_id : false;
+    }
+    
+    /**
+     * Get return request by ID
+     */
+    public static function get_return_request($id) {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $result = $wpdb->get_row(
+            $wpdb->prepare("SELECT * FROM $table_name WHERE id = %d", $id)
+        );
+        
+        if ($result && $result->uploaded_files) {
+            $result->uploaded_files = maybe_unserialize($result->uploaded_files);
+        }
+        
+        return $result;
+    }
+    
+    /**
+     * Get return requests by order ID
+     */
+    public static function get_return_requests_by_order($order_id) {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        return $wpdb->get_results(
+            $wpdb->prepare("SELECT * FROM $table_name WHERE order_id = %d ORDER BY request_date DESC", $order_id)
+        );
+    }
+    
+    /**
+     * Update return request status
+     */
+    public static function update_status($id, $status, $admin_notes = '') {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        return $wpdb->update(
+            $table_name,
+            array(
+                'status' => $status,
+                'admin_notes' => sanitize_textarea_field($admin_notes)
+            ),
+            array('id' => $id),
+            array('%s', '%s'),
+            array('%d')
+        );
+    }
+    
+    /**
+     * Get all return requests for admin
+     */
+    public static function get_all_return_requests($status = '', $limit = 20, $offset = 0) {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $where = '';
+        if (!empty($status)) {
+            $where = $wpdb->prepare(" WHERE status = %s", $status);
+        }
+        
+        $sql = "SELECT * FROM $table_name $where ORDER BY request_date DESC LIMIT %d OFFSET %d";
+        
+        return $wpdb->get_results(
+            $wpdb->prepare($sql, $limit, $offset)
+        );
+    }
+    
+    /**
+     * Get total return requests count
+     */
+    public static function get_total_count($status = '') {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $where = '';
+        if (!empty($status)) {
+            $where = $wpdb->prepare(" WHERE status = %s", $status);
+        }
+        
+        return $wpdb->get_var("SELECT COUNT(*) FROM $table_name $where");
+    }
+    
+    /**
+     * Check if order has pending return request
+     */
+    public static function has_pending_return_request($order_id) {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . self::TABLE_NAME;
+        
+        $count = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table_name WHERE order_id = %d AND status IN ('pending', 'processing')",
+                $order_id
+            )
+        );
+        
+        return $count > 0;
+    }
+}

--- a/includes/class-return-request-email.php
+++ b/includes/class-return-request-email.php
@@ -1,0 +1,179 @@
+<?php
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Return_Request_Email {
+    
+    /**
+     * Send admin notification email
+     */
+    public static function send_admin_notification($request_id, $return_data) {
+        // Get admin email
+        $admin_email = get_option('admin_email');
+        
+        // Get order details
+        $order = wc_get_order($return_data['order_id']);
+        if (!$order) {
+            return false;
+        }
+        
+        // Prepare email content
+        $subject = sprintf(__('New Return Request #%d for Order #%s', 'return-button'), $request_id, $order->get_order_number());
+        
+        $message = self::get_admin_email_template($request_id, $return_data, $order);
+        
+        // Set email headers
+        $headers = array(
+            'Content-Type: text/html; charset=UTF-8',
+            'From: ' . get_bloginfo('name') . ' <' . get_option('admin_email') . '>',
+            'Reply-To: ' . $return_data['customer_email']
+        );
+        
+        // Send email
+        return wp_mail($admin_email, $subject, $message, $headers);
+    }
+    
+    /**
+     * Get admin email template
+     */
+    private static function get_admin_email_template($request_id, $return_data, $order) {
+        $order_date = $order->get_date_created()->format('Y-m-d H:i:s');
+        $order_total = $order->get_formatted_order_total();
+        
+        $message = '<html><body>';
+        $message .= '<h2>' . sprintf(__('New Return Request #%d', 'return-button'), $request_id) . '</h2>';
+        
+        $message .= '<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Order Number:</td><td style="border: 1px solid #ddd; padding: 10px;">' . $order->get_order_number() . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Order Date:</td><td style="border: 1px solid #ddd; padding: 10px;">' . $order_date . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Order Total:</td><td style="border: 1px solid #ddd; padding: 10px;">' . $order_total . '</td></tr>';
+        $message .= '</table>';
+        
+        $message .= '<h3>' . __('Customer Information', 'return-button') . '</h3>';
+        $message .= '<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Name:</td><td style="border: 1px solid #ddd; padding: 10px;">' . esc_html($return_data['customer_name']) . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Email:</td><td style="border: 1px solid #ddd; padding: 10px;">' . esc_html($return_data['customer_email']) . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Phone:</td><td style="border: 1px solid #ddd; padding: 10px;">' . esc_html($return_data['customer_phone']) . '</td></tr>';
+        
+        if (!empty($return_data['customer_whatsapp'])) {
+            $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">WhatsApp:</td><td style="border: 1px solid #ddd; padding: 10px;">' . esc_html($return_data['customer_whatsapp']) . '</td></tr>';
+        }
+        $message .= '</table>';
+        
+        $message .= '<h3>' . __('Return Reason', 'return-button') . '</h3>';
+        $message .= '<div style="border: 1px solid #ddd; padding: 15px; background-color: #f9f9f9;">';
+        $message .= '<p>' . nl2br(esc_html($return_data['return_reason'])) . '</p>';
+        $message .= '</div>';
+        
+        // Add uploaded files information
+        if (!empty($return_data['uploaded_files'])) {
+            $message .= '<h3>' . __('Uploaded Files', 'return-button') . '</h3>';
+            $message .= '<ul>';
+            foreach ($return_data['uploaded_files'] as $file) {
+                $message .= '<li><a href="' . esc_url($file['file_url']) . '">' . esc_html($file['original_name']) . '</a> (' . size_format($file['file_size']) . ')</li>';
+            }
+            $message .= '</ul>';
+        }
+        
+        // Add admin link
+        $admin_url = admin_url('admin.php?page=return-requests&action=view&id=' . $request_id);
+        $message .= '<p style="margin-top: 30px;"><a href="' . $admin_url . '" style="background-color: #0073aa; color: white; padding: 10px 20px; text-decoration: none; border-radius: 3px;">View in Admin Dashboard</a></p>';
+        
+        $message .= '</body></html>';
+        
+        return $message;
+    }
+    
+    /**
+     * Send customer confirmation email
+     */
+    public static function send_customer_confirmation($request_id, $return_data) {
+        $subject = sprintf(__('Return Request #%d Submitted Successfully', 'return-button'), $request_id);
+        
+        $message = self::get_customer_email_template($request_id, $return_data);
+        
+        $headers = array(
+            'Content-Type: text/html; charset=UTF-8',
+            'From: ' . get_bloginfo('name') . ' <' . get_option('admin_email') . '>'
+        );
+        
+        return wp_mail($return_data['customer_email'], $subject, $message, $headers);
+    }
+    
+    /**
+     * Get customer email template
+     */
+    private static function get_customer_email_template($request_id, $return_data) {
+        $order = wc_get_order($return_data['order_id']);
+        
+        $message = '<html><body>';
+        $message .= '<h2>' . __('Return Request Submitted Successfully', 'return-button') . '</h2>';
+        
+        $message .= '<p>' . sprintf(__('Dear %s,', 'return-button'), esc_html($return_data['customer_name'])) . '</p>';
+        $message .= '<p>' . sprintf(__('Your return request #%d for order #%s has been submitted successfully.', 'return-button'), $request_id, $order->get_order_number()) . '</p>';
+        
+        $message .= '<h3>' . __('Request Details', 'return-button') . '</h3>';
+        $message .= '<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Request ID:</td><td style="border: 1px solid #ddd; padding: 10px;">#' . $request_id . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Order Number:</td><td style="border: 1px solid #ddd; padding: 10px;">#' . $order->get_order_number() . '</td></tr>';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">Status:</td><td style="border: 1px solid #ddd; padding: 10px;">Pending Review</td></tr>';
+        $message .= '</table>';
+        
+        $message .= '<p>' . __('We will review your request and get back to you within 2-3 business days.', 'return-button') . '</p>';
+        $message .= '<p>' . __('Thank you for your patience.', 'return-button') . '</p>';
+        
+        $message .= '<p>' . __('Best regards,', 'return-button') . '<br>';
+        $message .= get_bloginfo('name') . '</p>';
+        
+        $message .= '</body></html>';
+        
+        return $message;
+    }
+    
+    /**
+     * Send status update email to customer
+     */
+    public static function send_status_update($request_id, $new_status, $admin_notes = '') {
+        $return_request = Return_Request_Database::get_return_request($request_id);
+        if (!$return_request) {
+            return false;
+        }
+        
+        $order = wc_get_order($return_request->order_id);
+        
+        $subject = sprintf(__('Return Request #%d Status Update', 'return-button'), $request_id);
+        
+        $message = '<html><body>';
+        $message .= '<h2>' . sprintf(__('Return Request #%d Status Update', 'return-button'), $request_id) . '</h2>';
+        
+        $message .= '<p>' . sprintf(__('Dear %s,', 'return-button'), esc_html($return_request->customer_name)) . '</p>';
+        $message .= '<p>' . sprintf(__('The status of your return request #%d for order #%s has been updated.', 'return-button'), $request_id, $order->get_order_number()) . '</p>';
+        
+        $message .= '<table style="width: 100%; border-collapse: collapse; margin: 20px 0;">';
+        $message .= '<tr><td style="border: 1px solid #ddd; padding: 10px; font-weight: bold;">New Status:</td><td style="border: 1px solid #ddd; padding: 10px;">' . ucfirst($new_status) . '</td></tr>';
+        $message .= '</table>';
+        
+        if (!empty($admin_notes)) {
+            $message .= '<h3>' . __('Admin Notes', 'return-button') . '</h3>';
+            $message .= '<div style="border: 1px solid #ddd; padding: 15px; background-color: #f9f9f9;">';
+            $message .= '<p>' . nl2br(esc_html($admin_notes)) . '</p>';
+            $message .= '</div>';
+        }
+        
+        $message .= '<p>' . __('Thank you for your business.', 'return-button') . '</p>';
+        $message .= '<p>' . __('Best regards,', 'return-button') . '<br>';
+        $message .= get_bloginfo('name') . '</p>';
+        
+        $message .= '</body></html>';
+        
+        $headers = array(
+            'Content-Type: text/html; charset=UTF-8',
+            'From: ' . get_bloginfo('name') . ' <' . get_option('admin_email') . '>'
+        );
+        
+        return wp_mail($return_request->customer_email, $subject, $message, $headers);
+    }
+}

--- a/includes/class-return-request-handler.php
+++ b/includes/class-return-request-handler.php
@@ -1,0 +1,289 @@
+<?php
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Return_Request_Handler {
+    
+    public function __construct() {
+        add_filter('woocommerce_my_account_my_orders_actions', array($this, 'add_return_request_button'), 10, 2);
+        add_action('wp_ajax_submit_return_request', array($this, 'handle_return_request_submission'));
+        add_action('wp_ajax_nopriv_submit_return_request', array($this, 'handle_return_request_submission'));
+        add_action('wp_footer', array($this, 'add_return_request_modal'));
+    }
+    
+    /**
+     * Add return request button to order actions
+     */
+    public function add_return_request_button($actions, $order) {
+        // Check if return request is allowed for this order
+        if ($this->is_return_request_allowed($order)) {
+            $order_number = $order->get_order_number();
+            
+            $actions['return_request'] = array(
+                'url' => '#',
+                'name' => __('Return Request', 'return-button'),
+                'class' => 'button return-request-btn',
+                'data-order-id' => $order->get_id(),
+                'data-order-number' => $order_number
+            );
+        }
+        
+        return $actions;
+    }
+    
+    /**
+     * Check if return request is allowed for the order
+     */
+    private function is_return_request_allowed($order) {
+        // Check if order is completed
+        if ($order->get_status() !== 'completed') {
+            return false;
+        }
+        
+        // Check if there's already a pending return request
+        if (Return_Request_Database::has_pending_return_request($order->get_id())) {
+            return false;
+        }
+        
+        // Get order completion date
+        $completed_date = $order->get_date_completed();
+        if (!$completed_date) {
+            return false;
+        }
+        
+        // Calculate time periods
+        $return_period_days = get_option('return_button_return_period_days', 10);
+        $grace_period_days = get_option('return_button_grace_period_days', 10);
+        
+        $current_time = current_time('timestamp');
+        $completed_timestamp = $completed_date->getTimestamp();
+        
+        // Calculate the allowed return period (10 days after completion + 10 days grace period)
+        $return_start_time = $completed_timestamp + ($return_period_days * DAY_IN_SECONDS);
+        $return_end_time = $return_start_time + ($grace_period_days * DAY_IN_SECONDS);
+        
+        // Check if current time is within the return request window
+        return ($current_time >= $return_start_time && $current_time <= $return_end_time);
+    }
+    
+    /**
+     * Handle return request form submission
+     */
+    public function handle_return_request_submission() {
+        // Verify nonce
+        if (!wp_verify_nonce($_POST['nonce'], 'return_request_nonce')) {
+            wp_die(__('Security check failed', 'return-button'));
+        }
+        
+        // Sanitize and validate input data
+        $order_id = intval($_POST['order_id']);
+        $customer_name = sanitize_text_field($_POST['customer_name']);
+        $customer_email = sanitize_email($_POST['customer_email']);
+        $customer_phone = sanitize_text_field($_POST['customer_phone']);
+        $customer_whatsapp = sanitize_text_field($_POST['customer_whatsapp']);
+        $return_reason = sanitize_textarea_field($_POST['return_reason']);
+        
+        // Validate required fields
+        if (empty($order_id) || empty($customer_name) || empty($customer_email) || 
+            empty($customer_phone) || empty($return_reason)) {
+            wp_send_json_error(array('message' => __('Please fill all required fields.', 'return-button')));
+        }
+        
+        // Validate email
+        if (!is_email($customer_email)) {
+            wp_send_json_error(array('message' => __('Please enter a valid email address.', 'return-button')));
+        }
+        
+        // Get order and verify user permission
+        $order = wc_get_order($order_id);
+        if (!$order || $order->get_user_id() !== get_current_user_id()) {
+            wp_send_json_error(array('message' => __('Invalid order.', 'return-button')));
+        }
+        
+        // Check if return request is still allowed
+        if (!$this->is_return_request_allowed($order)) {
+            wp_send_json_error(array('message' => __('Return request is not allowed for this order.', 'return-button')));
+        }
+        
+        // Handle file uploads
+        $uploaded_files = $this->handle_file_uploads();
+        
+        // Prepare data for database
+        $return_data = array(
+            'order_id' => $order_id,
+            'user_id' => get_current_user_id(),
+            'customer_name' => $customer_name,
+            'customer_email' => $customer_email,
+            'customer_phone' => $customer_phone,
+            'customer_whatsapp' => $customer_whatsapp,
+            'return_reason' => $return_reason,
+            'uploaded_files' => $uploaded_files
+        );
+        
+        // Insert into database
+        $request_id = Return_Request_Database::insert_return_request($return_data);
+        
+        if ($request_id) {
+            // Send email notification
+            Return_Request_Email::send_admin_notification($request_id, $return_data);
+            
+            wp_send_json_success(array(
+                'message' => __('Return request submitted successfully!', 'return-button'),
+                'request_id' => $request_id
+            ));
+        } else {
+            wp_send_json_error(array('message' => __('Failed to submit return request. Please try again.', 'return-button')));
+        }
+    }
+    
+    /**
+     * Handle file uploads
+     */
+    private function handle_file_uploads() {
+        $uploaded_files = array();
+        
+        if (!empty($_FILES['return_files'])) {
+            $files = $_FILES['return_files'];
+            
+            // Setup upload directory
+            $upload_dir = wp_upload_dir();
+            $return_upload_dir = $upload_dir['basedir'] . '/return-requests/';
+            
+            // Create directory if it doesn't exist
+            if (!file_exists($return_upload_dir)) {
+                wp_mkdir_p($return_upload_dir);
+            }
+            
+            // Handle multiple files
+            if (is_array($files['name'])) {
+                for ($i = 0; $i < count($files['name']); $i++) {
+                    if ($files['error'][$i] === UPLOAD_ERR_OK) {
+                        $file_info = array(
+                            'name' => $files['name'][$i],
+                            'type' => $files['type'][$i],
+                            'tmp_name' => $files['tmp_name'][$i],
+                            'size' => $files['size'][$i]
+                        );
+                        
+                        $uploaded_file = $this->process_single_file($file_info, $return_upload_dir);
+                        if ($uploaded_file) {
+                            $uploaded_files[] = $uploaded_file;
+                        }
+                    }
+                }
+            } else {
+                // Handle single file
+                if ($files['error'] === UPLOAD_ERR_OK) {
+                    $uploaded_file = $this->process_single_file($files, $return_upload_dir);
+                    if ($uploaded_file) {
+                        $uploaded_files[] = $uploaded_file;
+                    }
+                }
+            }
+        }
+        
+        return $uploaded_files;
+    }
+    
+    /**
+     * Process single file upload
+     */
+    private function process_single_file($file_info, $upload_dir) {
+        // Validate file type
+        $allowed_image_types = array('image/jpeg', 'image/jpg', 'image/png');
+        $allowed_video_types = array('video/mp4');
+        $allowed_types = array_merge($allowed_image_types, $allowed_video_types);
+        
+        if (!in_array($file_info['type'], $allowed_types)) {
+            return false;
+        }
+        
+        // Validate file extension
+        $file_extension = strtolower(pathinfo($file_info['name'], PATHINFO_EXTENSION));
+        $allowed_extensions = array('jpg', 'jpeg', 'png', 'mp4');
+        
+        if (!in_array($file_extension, $allowed_extensions)) {
+            return false;
+        }
+        
+        // Generate unique filename
+        $filename = wp_unique_filename($upload_dir, sanitize_file_name($file_info['name']));
+        $file_path = $upload_dir . $filename;
+        
+        // Move uploaded file
+        if (move_uploaded_file($file_info['tmp_name'], $file_path)) {
+            return array(
+                'filename' => $filename,
+                'original_name' => $file_info['name'],
+                'file_path' => $file_path,
+                'file_url' => wp_upload_dir()['baseurl'] . '/return-requests/' . $filename,
+                'file_type' => $file_info['type'],
+                'file_size' => $file_info['size']
+            );
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Add return request modal to footer
+     */
+    public function add_return_request_modal() {
+        if (is_account_page()) {
+            ?>
+            <div id="return-request-modal" class="return-modal" style="display: none;">
+                <div class="return-modal-content">
+                    <div class="return-modal-header">
+                        <h3><?php _e('Return Request', 'return-button'); ?></h3>
+                        <span class="return-modal-close">&times;</span>
+                    </div>
+                    <form id="return-request-form" enctype="multipart/form-data">
+                        <div class="return-form-row">
+                            <label for="customer_name"><?php _e('Full Name', 'return-button'); ?> *</label>
+                            <input type="text" id="customer_name" name="customer_name" required>
+                        </div>
+                        
+                        <div class="return-form-row">
+                            <label for="customer_email"><?php _e('Email Address', 'return-button'); ?> *</label>
+                            <input type="email" id="customer_email" name="customer_email" required>
+                        </div>
+                        
+                        <div class="return-form-row">
+                            <label for="customer_phone"><?php _e('Phone Number', 'return-button'); ?> *</label>
+                            <input type="tel" id="customer_phone" name="customer_phone" required>
+                        </div>
+                        
+                        <div class="return-form-row">
+                            <label for="customer_whatsapp"><?php _e('WhatsApp Number', 'return-button'); ?></label>
+                            <input type="tel" id="customer_whatsapp" name="customer_whatsapp" placeholder="<?php _e('Leave empty if same as phone', 'return-button'); ?>">
+                        </div>
+                        
+                        <div class="return-form-row">
+                            <label for="return_reason"><?php _e('Return Reason', 'return-button'); ?> *</label>
+                            <textarea id="return_reason" name="return_reason" rows="4" required placeholder="<?php _e('Please describe why you want to return this order...', 'return-button'); ?>"></textarea>
+                        </div>
+                        
+                        <div class="return-form-row">
+                            <label for="return_files"><?php _e('Upload Files', 'return-button'); ?></label>
+                            <input type="file" id="return_files" name="return_files[]" multiple accept=".jpg,.jpeg,.png,.mp4">
+                            <small><?php _e('Allowed formats: JPG, JPEG, PNG images and MP4 videos only', 'return-button'); ?></small>
+                        </div>
+                        
+                        <div class="return-form-actions">
+                            <button type="button" class="return-btn-cancel"><?php _e('Cancel', 'return-button'); ?></button>
+                            <button type="submit" class="return-btn-submit"><?php _e('Submit Request', 'return-button'); ?></button>
+                        </div>
+                        
+                        <input type="hidden" id="order_id" name="order_id">
+                        <input type="hidden" name="action" value="submit_return_request">
+                        <input type="hidden" name="nonce" value="<?php echo wp_create_nonce('return_request_nonce'); ?>">
+                    </form>
+                </div>
+            </div>
+            <?php
+        }
+    }
+}

--- a/returnbutton-plugin.php
+++ b/returnbutton-plugin.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Plugin Name: Return Button Plugin
+ * Plugin URI: https://yourwebsite.com/
+ * Description: A WooCommerce extension that adds return request functionality to customer orders.
+ * Version: 1.0.0
+ * Author: Your Name
+ * License: GPL v2 or later
+ * Requires at least: 5.0
+ * Tested up to: 6.3
+ * WC requires at least: 4.0
+ * WC tested up to: 8.0
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Define plugin constants
+define('RETURN_BUTTON_PLUGIN_URL', plugin_dir_url(__FILE__));
+define('RETURN_BUTTON_PLUGIN_PATH', plugin_dir_path(__FILE__));
+define('RETURN_BUTTON_PLUGIN_VERSION', '1.0.0');
+
+class ReturnButtonPlugin {
+    
+    public function __construct() {
+        add_action('plugins_loaded', array($this, 'init'));
+        register_activation_hook(__FILE__, array($this, 'activate'));
+        register_deactivation_hook(__FILE__, array($this, 'deactivate'));
+    }
+    
+    /**
+     * Initialize the plugin
+     */
+    public function init() {
+        // Check if WooCommerce is active
+        if (!$this->is_woocommerce_active()) {
+            add_action('admin_notices', array($this, 'woocommerce_missing_notice'));
+            return;
+        }
+        
+        // Load plugin components
+        $this->load_dependencies();
+        $this->init_hooks();
+    }
+    
+    /**
+     * Check if WooCommerce is active
+     */
+    private function is_woocommerce_active() {
+        return class_exists('WooCommerce');
+    }
+    
+    /**
+     * Show admin notice if WooCommerce is not active
+     */
+    public function woocommerce_missing_notice() {
+        echo '<div class="error"><p><strong>Return Button Plugin</strong> requires WooCommerce to be installed and active.</p></div>';
+    }
+    
+    /**
+     * Load plugin dependencies
+     */
+    private function load_dependencies() {
+        require_once RETURN_BUTTON_PLUGIN_PATH . 'includes/class-return-request-handler.php';
+        require_once RETURN_BUTTON_PLUGIN_PATH . 'includes/class-return-request-admin.php';
+        require_once RETURN_BUTTON_PLUGIN_PATH . 'includes/class-return-request-database.php';
+        require_once RETURN_BUTTON_PLUGIN_PATH . 'includes/class-return-request-email.php';
+    }
+    
+    /**
+     * Initialize hooks
+     */
+    private function init_hooks() {
+        // Enqueue scripts and styles
+        add_action('wp_enqueue_scripts', array($this, 'enqueue_frontend_scripts'));
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
+        
+        // Initialize classes
+        new Return_Request_Handler();
+        new Return_Request_Admin();
+        new Return_Request_Email();
+    }
+    
+    /**
+     * Enqueue frontend scripts and styles
+     */
+    public function enqueue_frontend_scripts() {
+        if (is_account_page()) {
+            wp_enqueue_style('return-button-style', RETURN_BUTTON_PLUGIN_URL . 'assets/css/frontend.css', array(), RETURN_BUTTON_PLUGIN_VERSION);
+            wp_enqueue_script('return-button-script', RETURN_BUTTON_PLUGIN_URL . 'assets/js/frontend.js', array('jquery'), RETURN_BUTTON_PLUGIN_VERSION, true);
+            
+            // Localize script for AJAX
+            wp_localize_script('return-button-script', 'return_button_ajax', array(
+                'ajax_url' => admin_url('admin-ajax.php'),
+                'nonce' => wp_create_nonce('return_request_nonce'),
+                'messages' => array(
+                    'success' => __('Return request submitted successfully!', 'return-button'),
+                    'error' => __('Something went wrong. Please try again.', 'return-button'),
+                )
+            ));
+        }
+    }
+    
+    /**
+     * Enqueue admin scripts and styles
+     */
+    public function enqueue_admin_scripts($hook) {
+        if (strpos($hook, 'return-requests') !== false) {
+            wp_enqueue_style('return-button-admin-style', RETURN_BUTTON_PLUGIN_URL . 'assets/css/admin.css', array(), RETURN_BUTTON_PLUGIN_VERSION);
+            wp_enqueue_script('return-button-admin-script', RETURN_BUTTON_PLUGIN_URL . 'assets/js/admin.js', array('jquery'), RETURN_BUTTON_PLUGIN_VERSION, true);
+        }
+    }
+    
+    /**
+     * Plugin activation
+     */
+    public function activate() {
+        // Create database table
+        Return_Request_Database::create_table();
+        
+        // Set default options
+        add_option('return_button_return_period_days', 10);
+        add_option('return_button_grace_period_days', 10);
+    }
+    
+    /**
+     * Plugin deactivation
+     */
+    public function deactivate() {
+        // Clean up if needed
+    }
+}
+
+// Initialize the plugin
+new ReturnButtonPlugin();


### PR DESCRIPTION
Add a new WooCommerce plugin to enable conditional return requests from the My Account page, including a secure submission form, file uploads, and an admin dashboard for managing requests and sending notifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-b74a8688-c664-4b9f-b9ab-b62170d689a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b74a8688-c664-4b9f-b9ab-b62170d689a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

